### PR TITLE
Fixes #1

### DIFF
--- a/static.matterport.com/showcase/3.1.10.4-0-ga56ce8cdd/js/showcase.js
+++ b/static.matterport.com/showcase/3.1.10.4-0-ga56ce8cdd/js/showcase.js
@@ -45408,10 +45408,20 @@
           this.previousRefreshPromise = null,
           this.containerClasses = [_, w, b],
           this.endpoint = e + "?type=3"
+          this.firstRefresh = true
       }
       return t.prototype.needsRefresh = function () {
-          var t = this.urlContainer ? this.urlContainer.expires : Date.now();
-          return Date.now() + h.a.signedUrlRefreshBuffer > t
+          //var t = this.urlContainer ? this.urlContainer.expires : Date.now();
+          //return Date.now() + h.a.signedUrlRefreshBuffer > t
+
+          // The first refresh is necessary to avoid a black screen.
+          // However any further refreshes after some time has passed can cause the movement to stop working for some reason.
+          if (this.firstRefresh) {
+            this.firstRefresh = false;
+            return true;
+          } else {
+            return false;
+          }
         },
         t.prototype.refresh = function () {
           if (!this.needsRefresh())


### PR DESCRIPTION
This fixes the movement locking that consistently happens after 1-2 minutes.

There are still some rare occurrences of the movement locking due to some issue with a 4K tile texture, the error of which can sometimes be spotted in the console. However the locking does not always happen even when the error pops up. In any case with this fix it should be such a rare occurrence that it really does not matter.